### PR TITLE
fix: uses Address object directly

### DIFF
--- a/src/clients/SubtopiaRegistryClient.ts
+++ b/src/clients/SubtopiaRegistryClient.ts
@@ -5,7 +5,6 @@
 
 import algosdk, {
   algosToMicroalgos,
-  decodeAddress,
   decodeUint64,
   encodeAddress,
   AtomicTransactionComposer,
@@ -438,7 +437,7 @@ export class SubtopiaRegistryClient {
         registryID,
         new Uint8Array([
           ...getLockerBoxPrefix(lockerType),
-          ...decodeAddress(String(ownerAddress)).publicKey,
+          ...ownerAddress.publicKey,
         ]),
       )
       .do()
@@ -486,7 +485,7 @@ export class SubtopiaRegistryClient {
         appIndex: this.appID,
         name: new Uint8Array([
           ...getLockerBoxPrefix(LockerType.CREATOR),
-          ...decodeAddress(String(newOwnerAddress)).publicKey,
+          ...newOwnerAddress.publicKey,
         ]),
       },
     ];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,7 +12,6 @@ import algosdk, {
   ABIType,
   ABIArrayDynamicType,
   ABIUintType,
-  encodeAddress,
   Address,
 } from "algosdk";
 
@@ -431,7 +430,7 @@ export function parseTokenProductGlobalState(input: AppState) {
   for (const key in input) {
     if (keyMap[key]) {
       if (keyMap[key] === "manager") {
-        output[keyMap[key]] = encodeAddress(
+        output[keyMap[key]] = new Address(
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           input[key].valueRaw,


### PR DESCRIPTION
Refactors code to use the `Address` object directly instead of encoding/decoding addresses, enhancing efficiency and code clarity.
